### PR TITLE
feat(terminal): update `commandHandler` returns value

### DIFF
--- a/.changeset/nice-fishes-prove.md
+++ b/.changeset/nice-fishes-prove.md
@@ -1,0 +1,8 @@
+---
+'@kaiverse/k': minor
+'docs': minor
+---
+
+`Terminal`: `commandHandler` now should returns `'skip_default'` to skip the default handler instead of `true`.
+
+Update `Dialog` & `Terminal` docs.

--- a/apps/docs/src/content/docs/components/dialog.mdx
+++ b/apps/docs/src/content/docs/components/dialog.mdx
@@ -192,7 +192,7 @@ A Dialog that has no backdrop and also doesn't render on the top-layer. It can N
 `Dialog` component build on top of the HTML [`<dialog/>`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) element.
 
 By default, it respects the default accessibility behavior and settings of a `<dialog/>` element.
-You can opt-out some behaviors by using the `preventFocus` and `preventClose` [props](#shared-props).
+You can opt-out some behaviors by using the `preventFocus` and `preventClose` [props](#dialog-props).
 
 ### Keyboard interactions
 
@@ -242,20 +242,37 @@ We can customize the Dialog's backdrop by
 - Update [related CSS variables](#css-variables).
 - Apply styles directly to the `::backdrop` pseudo-element.
 
-<Demo path="dialog/backdrop-styling" client:visible />
-
-### Hide close button
-
-You can hide the close button by adding `hideCloseButton` prop to `Dialog.Header`
-or just get rid of the `Dialog.Header` component and create your own header.
-
-```jsx
-<Dialog>
-  <Dialog.Header hideCloseButton>
-    <h2>Dialog header</h2>
-  </Dialog.Header>
-</Dialog>
-```
+<Tabs>
+  <TabItem label="Playground">
+    <Demo path="dialog/backdrop-styling" client:visible />
+  </TabItem>
+  <TabItem label="Source code">
+    <Code
+      title="backdrop-styling.tsx"
+      lang="tsx"
+      code={`<Dialog
+    className="bg-base-100/90"
+    backdropProps={{
+      blur: 1,
+      opacity: 0.5,
+      background: 'linear-gradient(-25deg,rgba(238,174,202,0.6) 0%,rgba(148,187,233,0.6) 100%)',
+    }}
+  >
+    <Dialog.Header className="italic">
+      <Dialog.Title>Drawer header</Dialog.Title>
+    </Dialog.Header>
+    <Dialog.Content className="[&_code]:text-info">
+      We can use <code>backdropProps</code> to style the Dialog's backdrop.
+    </Dialog.Content>
+    <footer className="bg-[radial-gradient(circle,rgba(34,193,195,0.4)_0%,rgba(253,187,45,0.2)_100%)]">
+      <button type="button">
+        Close
+      </button>
+    </footer>
+  </Dialog>`}
+    />
+  </TabItem>
+</Tabs>
 
 ## Special Types
 
@@ -266,16 +283,16 @@ or just get rid of the `Dialog.Header` component and create your own header.
 
 ## `<Dialog>` Props
 
-| Name                                                          | Type                                                     | Default     | Description                                                                                                                         |
-| :------------------------------------------------------------ | :------------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------------------------------------------------------- |
-| `variant`                                                     | `'default'` \| `'drawer'`                                | `'default'` |                                                                                                                                     |
-| `dialogMode`                                                  | `'modal'` \| `'non-modal'`                               | `'modal'`   | `'modal'`<sup>(1)</sup><br/>`'non-modal'`<sup>(2)</sup>                                                                             |
-| `preventFocus`                                                | `boolean`                                                | `false`     | If `true`, disable a default behavior of `<dialog>` element: Browser won't autofocus on the first nested focusable element anymore. |
-| `preventClose`                                                | `boolean`                                                | `false`     | If `true`, the Dialog won't close when users press `Escape` key or click/tap on the backdrop.                                       |
-| `backdropProps`                                               | `BackdropProps`                                          | —           | Styling Dialog's backdrop.                                                                                                          |
-| `offset`                                                      | `number` \| `string`                                     | `0` (px)    | Dialog's offset from the edge of current viewport.                                                                                  |
-| ~~`classNames`~~ <Badge text="DEPRECATED" variant="danger" /> | `Partial<Record<DialogStylingSelectors, string>>`        | —           | Applies className to related selector element.                                                                                      |
-| ~~`styles`~~ <Badge text="DEPRECATED" variant="danger" />     | `Partial<Record<DialogStylingSelectors, CSSProperties>>` | —           | `styles[selector]` applies inline styles to related selector element ONLY if its `style` property has not been provided.            |
+| Name                                                          | Type                                                     | Default                                                      | Description                                                                                                                         |
+| :------------------------------------------------------------ | :------------------------------------------------------- | :----------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+| `variant`                                                     | `'default'` \| `'drawer'`                                | `'default'`                                                  |                                                                                                                                     |
+| `dialogMode`                                                  | `'modal'` \| `'non-modal'`                               | `'modal'`                                                    | `'modal'`<sup>(1)</sup><br/>`'non-modal'`<sup>(2)</sup>                                                                             |
+| `preventFocus`                                                | `boolean`                                                | `false`                                                      | If `true`, disable a default behavior of `<dialog>` element: Browser won't autofocus on the first nested focusable element anymore. |
+| `preventClose`                                                | `boolean`                                                | `false`                                                      | If `true`, the Dialog won't close when users press `Escape` key or click/tap on the backdrop.                                       |
+| `backdropProps`                                               | `BackdropProps`                                          | `background: rgba(0,0,0,0.4)`<br/>`blur: 0`<br/>`opacity: 1` | Styling Dialog's backdrop.                                                                                                          |
+| `offset`                                                      | `number` \| `string`                                     | `0` (px)                                                     | Dialog's offset from the edge of current viewport.                                                                                  |
+| ~~`classNames`~~ <Badge text="DEPRECATED" variant="danger" /> | `Partial<Record<DialogStylingSelectors, string>>`        | —                                                            | Applies className to related selector element.                                                                                      |
+| ~~`styles`~~ <Badge text="DEPRECATED" variant="danger" />     | `Partial<Record<DialogStylingSelectors, CSSProperties>>` | —                                                            | `styles[selector]` applies inline styles to related selector element ONLY if its `style` property has not been provided.            |
 
 ### Variant `'drawer'`
 

--- a/apps/docs/src/content/docs/components/terminal.mdx
+++ b/apps/docs/src/content/docs/components/terminal.mdx
@@ -3,7 +3,7 @@ title: Terminal
 description: Terminal UI component.
 ---
 
-import {Aside} from '@astrojs/starlight/components'
+import {Aside, Code, Tabs, TabItem} from '@astrojs/starlight/components'
 import Demo from '@/demo'
 
 ## Import
@@ -24,52 +24,64 @@ Try command `hello` and then `clear` in the terminal below:
 
 ## Handle Command
 
-You can provide your handler by using `commandHandler` [prop](#terminal-props).
-Your function should returns `true` if the command is manually handled. Otherwise, commands will be executed by default handler.
+You can provide your custom handler by using `commandHandler` [prop](#terminal-props).<br/>
+Your function should returns `"skip_default"` if the command is manually handled and/or you wanna skip the default handler.<br/>
+Otherwise, commands will be executed by it.
 
 ### Default Commands
 
-- `clear` - clear the terminal
+- `clear` or `cls` - clear the terminal
 - Others - println: "command not found".
 
 ### Helpers
 
 `commandHandler` prop also has a collection of built-in helpers (2nd argument), you can call it to manipulate the terminal's history (log) section.
 
-<Demo path="terminal/helpers" client:visible />
-
-```jsx title="using-commandHandler.tsx"
-<Terminal
-  commandHandler={(command, {printNode, println}) => {
-    const currentTime = new Date().toLocaleTimeString()
-    printNode(
-      <>
-        <span className="text-green-400">{currentTime}</span> [
-        <code className="text-blue-400">printNode</code>]{' '}
-        <img className="size-5 invert" src="..." /> Command: {command}
-      </>,
-    )
-    println(`\n${currentTime} [println] Command: ${command}`)
-    return true
-  }}
-/>
-```
-
-```jsx title="call-helpers-via-ref.tsx"
-import {Terminal, type TerminalRef} from '@kaiverse/k/ui'
-
-const terminalRef = useRef<TerminalRef>(null)
-
-<Terminal ref={terminalRef} />
-<button
-  type="button"
-  onClick={() =>
-    terminalRef.current?.println(`${new Date().toLocaleTimeString()} [println]: Trigger println via TerminalRef`)
-  }
->
-  Println
-</button>
-```
+<Tabs>
+  <TabItem label="Playground">
+    <Demo path="terminal/helpers" client:visible />
+  </TabItem>
+  <TabItem label="commandHandler example">
+    <Code
+      title="using-commandHandler.tsx"
+      lang="tsx"
+      code={`<Terminal
+    commandHandler={(rawCommand, {printNode, println}) => {
+      const command = rawCommand.trim()\n
+      if (command === 'print' || command === 'p') {
+        const currentTime = new Date().toLocaleTimeString()\n
+        printNode(
+          <>
+            <span className="text-green-400">{currentTime}</span> 
+            [<code className="text-blue-400">printNode</code>] <img src="..." /> Command: {command}
+          </>,
+        )
+        println(\`\\n\${currentTime} [println] Command: \${command}\`)
+        return 'skip_default' // skip the default handler
+      }\n
+      // let the default handler handle all other commands
+    }}
+  />`}
+    />
+  </TabItem>
+  <TabItem label="Access via ref">
+    <Code
+      title="call-helpers-via-ref.tsx"
+      lang="tsx"
+      code={`import {Terminal, type TerminalRef} from '@kaiverse/k/ui'\n
+  const terminalRef = useRef<TerminalRef>(null)\n
+  <Terminal ref={terminalRef} />\n
+  <button
+    type="button"
+    onClick={() =>
+      terminalRef.current?.println(\`\${new Date().toLocaleTimeString()} [println]: Trigger println via TerminalRef\`)
+    }
+  >
+    Println
+  </button>`}
+    />
+  </TabItem>
+</Tabs>
 
 #### `printNode`
 
@@ -92,7 +104,7 @@ Prints a string with a newline.
 
 #### `clearHistory`
 
-Clears the terminal history. Same as the default `clear` command.
+Clears the terminal history. Same as the default `clear` or `cls` command.
 
 ## Customization
 
@@ -159,14 +171,14 @@ See `TerminalStylingSelectors` in the [Special Types](#special-types) section be
 
 ## `<Terminal>` Props
 
-| Name                | Type                                                       | Default                                | Description                                                                                                                                |
-| :------------------ | :--------------------------------------------------------- | :------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| `classNames`        | `Partial<Record<TerminalStylingSelectors, string>>`        | —                                      | Applies className to related selector element.                                                                                             |
-| `styles`            | `Partial<Record<TerminalStylingSelectors, CSSProperties>>` | —                                      | Applies inline styles to related selector element.                                                                                         |
-| `title`             | `string`                                                   | —                                      | Terminal window title.                                                                                                                     |
-| `greeting`          | `ReactNode`                                                | —                                      | Greating section. It will be printed on top of terminal's history section.                                                                 |
-| `theme`             | `'macos'` \| `'window'`                                    | `'macos'`                              |                                                                                                                                            |
-| `commandPrefix`     | `string`                                                   | `'$'` (`'>'` if `theme` is `'window'`) |                                                                                                                                            |
-| `commandHandler`    | `(command: string, helper: TerminalHelpers) => boolean`    | —                                      | Provide custom command handler. Returns `true` if the command is manually handled, otherwise commands will be executed by default handler. |
-| `hideWindowCtrls`   | `boolean`                                                  | `false`                                | Hide window controls.                                                                                                                      |
-| `...htmlAttributes` | `Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>`          | —                                      | Others HTML attributes.<br/><small>_Note_: `onClick` event handler is not supported.</small>                                               |
+| Name                | Type                                                                   | Default                                | Description                                                                                                                                                                                         |
+| :------------------ | :--------------------------------------------------------------------- | :------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `classNames`        | `Partial<Record<TerminalStylingSelectors, string>>`                    | —                                      | Applies className to related selector element.                                                                                                                                                      |
+| `styles`            | `Partial<Record<TerminalStylingSelectors, CSSProperties>>`             | —                                      | Applies inline styles to related selector element.                                                                                                                                                  |
+| `title`             | `string`                                                               | —                                      | Terminal window title.                                                                                                                                                                              |
+| `greeting`          | `ReactNode`                                                            | —                                      | Greating section. It will be printed on top of terminal's history section.                                                                                                                          |
+| `theme`             | `'macos'` \| `'window'`                                                | `'macos'`                              |                                                                                                                                                                                                     |
+| `commandPrefix`     | `string`                                                               | `'$'` (`'>'` if `theme` is `'window'`) |                                                                                                                                                                                                     |
+| `commandHandler`    | `(command: string, helper: TerminalHelpers) => 'skip_default' \| void` | —                                      | Provide custom command handler. Returns `"skip_default"` if the command is manually handled and/or you wanna skip the default handler.<br/>Otherwise, commands will be executed by default handler. |
+| `hideWindowCtrls`   | `boolean`                                                              | `false`                                | Hide window controls.                                                                                                                                                                               |
+| `...htmlAttributes` | `Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>`                      | —                                      | Others HTML attributes.<br/><small>_Note_: `onClick` event handler is not supported.</small>                                                                                                        |

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -47,15 +47,15 @@ yarn add @kaiverse/k
   components.
 </Aside>
 
-If you are looking for a component library with a wide range of components such as `<Button>`, `<Input>`, `<Layout>`, etc.
-I highly recommend <a href="https://ui.shadcn.com/" target="_blank" rel="noopener">shadcn UI</a>, <a href="https://mantine.dev/" target="_blank" rel="noopener">Mantine</a>, and <a href="https://daisyui.com/" target="_blank" rel="noopener">daisyui</a> (if you love TailwindCSS).
+If you are looking for a component library with a wide range of components from basic (eg: `<Button>`, `<Input>`, `<Layout>`) to complex (such as `<RichTextEditor>`, `<Chart>`),
+I highly recommend <a href="https://ui.shadcn.com/" target="_blank" rel="noopener">shadcn UI</a>, <a href="https://mantine.dev/" target="_blank" rel="noopener">Mantine</a>, and <a href="https://daisyui.com/" target="_blank" rel="noopener">daisyui</a>.
 
 ## Usage with Server Components
 
 All `@kaiverse/k/ui` components already have `'use client';` directive at the top of the file.
 
 <Aside type="caution">
-  Some components like [Dialog](components/dialog) have associated compound components. Compound
+  Some components like [Dialog](/components/dialog) have associated compound components. Compound
   components cannot be used in server components. Instead of `Component.X` syntax, use `ComponentX`
   or add `'use client'` directive to the top of your pages/layouts/components.
 </Aside>
@@ -94,7 +94,7 @@ To enable tree shaking with app router, enable experimental `optimizePackageImpo
 
 ## Usage with Astro
 
-<Aside title="No one asked">This documentation is built with Astro btw.</Aside>
+<Aside title="No one asked but">This documentation is built with Astro btw.</Aside>
 
 Please make sure your Astro project supports React. If not, follow the <a href="https://docs.astro.build/guides/integrations-guide/react/" target="_blank" rel="noopener">official integration guide</a>.
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Kaiverse
-description: Collection of powerful utilities, React components, and hooks.<br/>Typescript fully supported.
+description: Collection of powerful utilities, uncommon React components, and hooks.<br/>Typescript fully supported.
 template: splash
 hero:
   title: Build website faster with better DX
-  tagline: Collection of powerful utilities, React components, and hooks.<br/>Typescript fully supported.
+  tagline: Collection of powerful utilities, uncommon React components, and hooks.
   image:
     file: ../../assets/houston.webp
   actions:

--- a/apps/docs/src/demo/dialog/backdrop-styling.tsx
+++ b/apps/docs/src/demo/dialog/backdrop-styling.tsx
@@ -21,7 +21,7 @@ export default function BackdropStyling() {
         }}
       >
         <Dialog.Header className="italic">
-          <h2>Drawer header</h2>
+          <Dialog.Title>Drawer header</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content className="[&_code]:text-info">
           We can use <code>backdropProps</code> to style the Dialog's backdrop.

--- a/apps/docs/src/demo/dialog/offset.tsx
+++ b/apps/docs/src/demo/dialog/offset.tsx
@@ -3,19 +3,41 @@ import {useState} from 'react'
 
 export default function OffsetDialog() {
   const [openDialog, setOpenDialog] = useState(false)
+  const [offset, setOffset] = useState(16)
 
   return (
     <>
       <button className="btn btn-neutral" type="button" onClick={() => setOpenDialog(true)}>
         Open Dialog
       </button>
-      <Dialog open={openDialog} variant="drawer" offset={16} onClose={() => setOpenDialog(false)}>
+      <Dialog
+        open={openDialog}
+        variant="drawer"
+        offset={offset}
+        onClose={() => setOpenDialog(false)}
+      >
         <Dialog.Header>
           <Dialog.CloseButton />
         </Dialog.Header>
         <Dialog.Content>
           You can set the <code>offset</code> prop to adjust the Dialog's position from the edge of
-          the viewport
+          the viewport.
+          <br />
+          Try dragging the range slider below.
+          <label className="form-control mt-4">
+            <p>
+              Offset: <strong>{offset}</strong>
+            </p>
+            <input
+              className="range range-sm"
+              title={offset.toString()}
+              type="range"
+              min={0}
+              max={64}
+              value={offset}
+              onChange={(e) => setOffset(parseInt(e.target.value))}
+            />
+          </label>
         </Dialog.Content>
         <footer className="p-4">
           <button className="btn btn-secondary" type="button" onClick={() => setOpenDialog(false)}>

--- a/apps/docs/src/demo/terminal/helpers.tsx
+++ b/apps/docs/src/demo/terminal/helpers.tsx
@@ -1,4 +1,4 @@
-import {Terminal, type TerminalRef} from '@kaiverse/k/ui'
+import {Terminal, TERMINAL_COMMANDS, type TerminalRef} from '@kaiverse/k/ui'
 import {useRef} from 'react'
 
 export default function TerminalHelpers() {
@@ -19,26 +19,34 @@ export default function TerminalHelpers() {
             <br />
             <code className="text-rose-400">clearHistory</code> - clears the terminal history
             <br />
-            Try typing anything
+            Try command <span className="font-bold text-primary">print</span> or{' '}
+            <code className="font-semibold text-primary">p</code> to log messages, and then{' '}
+            <span className="font-bold text-rose-400">{TERMINAL_COMMANDS.CLEAR}</span>.
           </p>
         }
-        commandHandler={(command, {printNode, println}) => {
-          const currentDateTime = new Date().toLocaleTimeString()
+        commandHandler={(rawCommand, {printNode, println}) => {
+          const command = rawCommand.trim()
 
-          printNode(
-            <>
-              <span className="text-green-400">{currentDateTime}</span> [
-              <code className="text-blue-400">printNode</code>]{' '}
-              <img
-                className="size-5"
-                src="https://icons.iconarchive.com/icons/iconarchive/dogecoin-to-the-moon/48/Doge-icon.png"
-                alt="@kaiverse/k"
-              />{' '}
-              Command: {command}
-            </>,
-          )
-          println(`\n${currentDateTime} [println] Command: ${command}`)
-          return true
+          if (command === 'print' || command === 'p') {
+            const currentDateTime = new Date().toLocaleTimeString()
+
+            printNode(
+              <>
+                <span className="text-green-400">{currentDateTime}</span> [
+                <code className="text-blue-400">printNode</code>]{' '}
+                <img
+                  className="size-5"
+                  src="https://icons.iconarchive.com/icons/iconarchive/dogecoin-to-the-moon/48/Doge-icon.png"
+                  alt="@kaiverse/k"
+                />{' '}
+                Command: {command}
+              </>,
+            )
+            println(`\n${currentDateTime} [println] Command: ${command}`)
+            return 'skip_default' // skip the default handler
+          }
+
+          // let the default handler handle all other commands
         }}
       />
 

--- a/apps/docs/src/demo/terminal/usage.tsx
+++ b/apps/docs/src/demo/terminal/usage.tsx
@@ -21,9 +21,8 @@ L\n\n`}
       commandHandler={(command, {println}) => {
         if (command === 'hello') {
           println('Hello world👋!')
-          return true
+          return 'skip_default'
         }
-        return false
       }}
       style={{maxHeight: '30dvh'}}
     />

--- a/packages/shared/lib/components/terminal/constants.ts
+++ b/packages/shared/lib/components/terminal/constants.ts
@@ -13,4 +13,5 @@ export const TERMINAL_CTRLS = {
 
 export const TERMINAL_COMMANDS = {
   CLEAR: 'clear',
+  CLS: 'cls',
 } as const

--- a/packages/shared/lib/components/terminal/terminal.tsx
+++ b/packages/shared/lib/components/terminal/terminal.tsx
@@ -46,12 +46,13 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
 
       e.currentTarget.reset()
 
-      if (commandHandler?.(command, helpers)) {
+      if (commandHandler?.(command, helpers) === 'skip_default') {
         return
       }
 
       switch (command.toLowerCase()) {
-        case TERMINAL_COMMANDS.CLEAR: {
+        case TERMINAL_COMMANDS.CLEAR:
+        case TERMINAL_COMMANDS.CLS: {
           helpers.clearHistory()
           break
         }

--- a/packages/shared/lib/components/terminal/types.ts
+++ b/packages/shared/lib/components/terminal/types.ts
@@ -44,13 +44,13 @@ type Props = {
    * Custom command handler
    * ___
    * Default commands:
-   * - `clear` - clear the terminal
+   * - `clear` | `cls` - clear the terminal history.
    * - Others - println: "command not found".
    *
    * @param command need to be handled
-   * @returns `true` if the command is manually handled. `false` - commands will be executed by default handler.
+   * @returns `skip_default` if the command is manually handled and you wanna skip the default handler. Otherwise, commands will be executed by it.
    */
-  commandHandler?: (command: string, helper: TerminalHelpers) => boolean
+  commandHandler?: (command: string, helper: TerminalHelpers) => 'skip_default' | void
   /** @default 'macos' */
   theme?: 'macos' | 'window'
   /** @default false */

--- a/packages/shared/src/App.tsx
+++ b/packages/shared/src/App.tsx
@@ -74,7 +74,7 @@ A        \\/       \\/          \\/            \\/     \\/
 L\n`}
               </>,
             )
-            return true
+            return 'skip_default'
           }}
         />
       </div>


### PR DESCRIPTION
`commandHandler` now should returns `'skip_default'` to skip the default handler instead of `true`.