### PR TITLE
fix(ci/cd): temp vite.config.*.timestamp* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ lerna-debug.log*
 *.sw?
 
 routeTree.gen.ts
+**/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,16 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  {ignores: ['dist', '**/dist', '**/*.d.ts', 'node_modules', '**/routeTree.gen.ts']},
+  {
+    ignores: [
+      'dist',
+      '**/dist',
+      '**/*.d.ts',
+      'node_modules',
+      '**/routeTree.gen.ts',
+      '**/vite.config.*.timestamp*',
+    ],
+  },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {


### PR DESCRIPTION
Temporary `vite.config.*.timestamp*` files have not been cleaned up. Can causes race conditions when running multiple build/lint/type-checking/etc processes simultaneously.